### PR TITLE
fix(cors): correct credentials header name

### DIFF
--- a/internal/middleware/cors.go
+++ b/internal/middleware/cors.go
@@ -23,7 +23,7 @@ func CORS(config CORSConfig) func(http.Handler) http.Handler {
 				// Set specific origin (required for credentials)
 				w.Header().Set("Access-Control-Allow-Origin", origin)
 				// Enable credentials (cookies, authorization headers)
-				w.Header().Set("Access-Control-Allow-Origin", "true")
+				w.Header().Set("Access-Control-Allow-Credentials", "true")
 
 				log.Debug().
 					Str("origin", origin).


### PR DESCRIPTION
## Summary
- Fixed CORS middleware bug where `Access-Control-Allow-Origin` was set twice instead of `Access-Control-Allow-Credentials`

## Problem
The CORS middleware had a typo on line 26 that set `Access-Control-Allow-Origin` to `"true"` instead of setting `Access-Control-Allow-Credentials`. This prevented browsers from including credentials (cookies, authorization headers) in cross-origin requests, breaking authenticated API calls from frontend clients.

## Solution
Changed the header name from `Access-Control-Allow-Origin` to `Access-Control-Allow-Credentials` so the credential support works as intended.

## Test plan
- [ ] Verify cross-origin requests from frontend include cookies/auth headers
- [ ] Confirm preflight OPTIONS requests return correct CORS headers
- [ ] Test authenticated endpoints work from allowed origins