### PR TITLE
fix(auth): return JWT token from register endpoint

### DIFF
--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -29,7 +29,7 @@ func (h *Handler) Register(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create user and profile with auth service
-	user, profile, err := h.authService.Register(req.Username, req.Password, req.FirstName, req.LastName)
+	user, profile, token, err := h.authService.Register(req.Username, req.Password, req.FirstName, req.LastName)
 	if err != nil {
 		// Specific errors
 		if err.Error() == "username already exists" {
@@ -49,16 +49,16 @@ func (h *Handler) Register(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create response
-	response := map[string]interface{}{
-		"message": "User successfully registered",
-		"user": model.UserSummary{
+	response := model.AuthResponse{
+		Token: token,
+		User: model.UserSummary{
 			UserID:    user.ID,
 			Username:  user.Username,
 			Role:      user.Role,
 			FirstName: user.FirstName,
 			LastName:  user.LastName,
 		},
-		"profile": profile,
+		Profile: profile,
 	}
 
 	log.Info().

--- a/internal/service/auth_service.go
+++ b/internal/service/auth_service.go
@@ -45,25 +45,25 @@ func (s *AuthService) Login(username, password string) (string, error) {
 }
 
 // Creates new account
-func (s *AuthService) Register(username, password, firstName, lastName string) (*model.User, *model.Profile, error) {
+func (s *AuthService) Register(username, password, firstName, lastName string) (*model.User, *model.Profile, string, error) {
 	// Validate password strength
 	if err := auth.ValidatePasswordStrength(password); err != nil {
-		return nil, nil, fmt.Errorf("invalid password: %w", err)
+		return nil, nil, "", fmt.Errorf("invalid password: %w", err)
 	}
 
 	// Check if username already exists
 	exists, err := s.db.UserExists(username)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to check username availability: %w", err)
+		return nil, nil, "", fmt.Errorf("failed to check username availability: %w", err)
 	}
 	if exists {
-		return nil, nil, fmt.Errorf("username already exists")
+		return nil, nil, "", fmt.Errorf("username already exists")
 	}
 
 	// Hash password
 	hashedPassword, err := auth.HashPassword(password)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to hash password: %w", err)
+		return nil, nil, "", fmt.Errorf("failed to hash password: %w", err)
 	}
 
 	// Create user object
@@ -77,7 +77,7 @@ func (s *AuthService) Register(username, password, firstName, lastName string) (
 
 	// Save to database
 	if err := s.db.CreateUser(user); err != nil {
-		return nil, nil, fmt.Errorf("failed to create user: %w", err)
+		return nil, nil, "", fmt.Errorf("failed to create user: %w", err)
 	}
 
 	// Create profile for user
@@ -95,11 +95,17 @@ func (s *AuthService) Register(username, password, firstName, lastName string) (
 	// Add new profile to the database
 	createdProfile, err := s.db.CreateProfile(profile)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create profile: %w", err)
+		return nil, nil, "", fmt.Errorf("failed to create profile: %w", err)
+	}
+
+	// Generate JWT token so the user is immediately authenticated after registration
+	token, err := s.tokenProvider.CreateToken(user.Username, user.Role)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("failed to generate token: %w", err)
 	}
 
 	// user.ID is now populated by CreateUser bc of RETURNING clause
-	return user, createdProfile, nil
+	return user, createdProfile, token, nil
 }
 
 // Change a user's password


### PR DESCRIPTION
## Summary

The register endpoint was not returning a JWT token in its response, causing newly registered users to be immediately logged out when they attempted any authenticated action (e.g. creating a post).

## Changes

- Updated `AuthService.Register` to generate and return a JWT token after account creation
- Updated the `Register` handler to return `AuthResponse` (matching the login response shape) so the frontend receives a valid token on successful registration

## Testing

- [x] Register a new account and immediately create a post without being redirected to login
- [x] Verify the register response body contains a valid `token` field
- [x] Verify login flow is unaffected