### PR TITLE
feat(notifications): link notifications to comments via comment_id

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -73,8 +73,10 @@ CREATE TABLE notifications (
     message VARCHAR(255) NOT NULL,
     is_read BOOLEAN NOT NULL DEFAULT FALSE,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    comment_id INTEGER,
     FOREIGN KEY (user_id) REFERENCES users (user_id) ON DELETE CASCADE,
-    FOREIGN KEY (post_id) REFERENCES posts (post_id) ON DELETE CASCADE
+    FOREIGN KEY (post_id) REFERENCES posts (post_id) ON DELETE CASCADE,
+    FOREIGN KEY (comment_id) REFERENCES comments (comment_id) ON DELETE CASCADE
 );
 
 -- Create indexes for better query performance

--- a/internal/handler/handlers.go
+++ b/internal/handler/handlers.go
@@ -977,9 +977,10 @@ func (h *Handler) createNotification(comment model.Comment) {
 	}
 
 	notif := model.Notification{
-		UserId:  post.UserId,
-		PostId:  comment.PostId,
-		Message: fmt.Sprintf("%s commented on your post!", comment.Author),
+		UserId:    post.UserId,
+		PostId:    comment.PostId,
+		Message:   fmt.Sprintf("%s commented on your post!", comment.Author),
+		CommentId: &comment.CommentId,
 	}
 
 	if err := h.db.CreateNotification(&notif); err != nil {

--- a/internal/model/models.go
+++ b/internal/model/models.go
@@ -36,15 +36,16 @@ type User struct {
 	Username       string `json:"username" db:"username"`
 	HashedPassword string `json:"-" db:"hashed_password"`
 	Role           string `json:"role" db:"role"`
-	FirstName string `json:"first_name" db:"first_name"`
-	LastName string `json:"last_name" db:"last_name"`
+	FirstName      string `json:"first_name" db:"first_name"`
+	LastName       string `json:"last_name" db:"last_name"`
 }
 
 type Notification struct {
-	ID int `json:"notification_id" db:"notification_id"`
-	UserId int `json:"user_id" db:"user_id"`
-	PostId int `json:"post_id" db:"post_id"`
-	Message string `json:"message" db:"message"`
-	IsRead bool `json:"is_read" db:"is_read"`
+	ID        int       `json:"notification_id" db:"notification_id"`
+	UserId    int       `json:"user_id" db:"user_id"`
+	PostId    int       `json:"post_id" db:"post_id"`
+	Message   string    `json:"message" db:"message"`
+	IsRead    bool      `json:"is_read" db:"is_read"`
 	CreatedAt time.Time `json:"created_at" db:"created_at"`
+	CommentId *int      `json:"comment_id" db:"comment_id"`
 }

--- a/internal/repository/database.go
+++ b/internal/repository/database.go
@@ -586,7 +586,7 @@ func (db *DB) GetNotificationsByUserId(userId int) ([]model.Notification, error)
 	var notifications []model.Notification
 	for rows.Next() {
 		var notif model.Notification
-		err := rows.Scan(&notif.ID, &notif.UserId, &notif.PostId, &notif.Message, &notif.IsRead, &notif.CreatedAt)
+		err := rows.Scan(&notif.ID, &notif.UserId, &notif.PostId, &notif.Message, &notif.IsRead, &notif.CreatedAt, &notif.CommentId)
 
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan for notifications: %w", err)
@@ -630,14 +630,15 @@ func (db *DB) MarkNotificationAsRead(notificationId int) error {
 // Create a new notification
 func (db *DB) CreateNotification(notif *model.Notification) error {
 	query := `
-		INSERT INTO notifications (user_id, post_id, message) 
-		VALUES ($1, $2, $3)
+		INSERT INTO notifications (user_id, post_id, message, comment_id) 
+		VALUES ($1, $2, $3, $4)
 	`
 
 	_, err := db.Exec(query,
 		notif.UserId,
 		notif.PostId,
 		notif.Message,
+		notif.CommentId,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create notification: %w", err)


### PR DESCRIPTION
## Summary
Extends the notifications system to include a reference to the source comment that triggered the notification, enabling comment-linked notifications.

## Changes
- Add `comment_id` nullable column and foreign key constraint to `notifications` table referencing `comments`
- Add `CommentId *int` field to `Notification` model with proper struct tag alignment
- Include `comment_id` in notification creation query and row scanning
- Populate `CommentId` when creating notifications from comment events

## Testing
- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing complete