### PR TITLE
feat(reactions): add likes and dislikes for posts and comments

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -150,6 +150,10 @@ func setupRouter(h *handler.Handler, authMiddleware *middleware.AuthMiddleware) 
 	protected.HandleFunc("/notifications", h.GetNotificationsByUserId).Methods("GET")
 	protected.HandleFunc("/notifications/{notificationId}/read", h.MarkNotificationAsRead).Methods("PUT")
 
+	// Comment and post reactions
+	protected.HandleFunc("/posts/{postId}/react", h.ReactToPost).Methods("POST")
+	protected.HandleFunc("/comments/{commentId}/react", h.ReactToComment).Methods("POST")
+
 	// User management (Admin only)
 	admin.HandleFunc("/users", h.GetAllUsers).Methods("GET")
 	admin.HandleFunc("/users/{userId}", h.GetUserById).Methods("GET")

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -113,9 +113,9 @@ func setupRouter(h *handler.Handler, authMiddleware *middleware.AuthMiddleware) 
 
 	// Comment endpoints
 	// GET
-	api.HandleFunc("/comments", h.GetAllComments).Methods("GET")
-	api.HandleFunc("/posts/{postId}/comments", h.GetCommentsOnPost).Methods("GET")
-	api.HandleFunc("/comments/{commentId}", h.GetCommentById).Methods("GET")
+	protected.HandleFunc("/comments", h.GetAllComments).Methods("GET")
+	protected.HandleFunc("/posts/{postId}/comments", h.GetCommentsOnPost).Methods("GET")
+	protected.HandleFunc("/comments/{commentId}", h.GetCommentById).Methods("GET")
 	// POST
 	protected.HandleFunc("/posts/{postId}/comments", h.CreateComment).Methods("POST")
 	// PUT
@@ -125,9 +125,9 @@ func setupRouter(h *handler.Handler, authMiddleware *middleware.AuthMiddleware) 
 
 	// Post endpoints
 	// GET
-	api.HandleFunc("/posts", h.GetAllPosts).Methods("GET")
-	api.HandleFunc("/posts/{postId}", h.GetPostById).Methods("GET")
-	api.HandleFunc("/posts/user/{userId}", h.GetPostsByUserId).Methods("GET")
+	protected.HandleFunc("/posts", h.GetAllPosts).Methods("GET")
+	protected.HandleFunc("/posts/{postId}", h.GetPostById).Methods("GET")
+	protected.HandleFunc("/posts/user/{userId}", h.GetPostsByUserId).Methods("GET")
 	// POST
 	protected.HandleFunc("/posts", h.CreatePost).Methods("POST")
 	// PUT
@@ -136,8 +136,8 @@ func setupRouter(h *handler.Handler, authMiddleware *middleware.AuthMiddleware) 
 	protected.HandleFunc("/posts/{postId}", h.DeletePost).Methods("DELETE")
 
 	// Profile endpoints
-	api.HandleFunc("/profiles", h.GetAllProfiles).Methods("GET")
-	api.HandleFunc("/profiles/{userId}", h.GetProfileByUserId).Methods("GET")
+	protected.HandleFunc("/profiles", h.GetAllProfiles).Methods("GET")
+	protected.HandleFunc("/profiles/{userId}", h.GetProfileByUserId).Methods("GET")
 	// PUT
 	protected.HandleFunc("/profiles/{userId}", h.UpdateProfile).Methods("PUT")
 

--- a/database.sql
+++ b/database.sql
@@ -9,6 +9,10 @@
 -- ----------------------------------------------------------------------
 
 -- Drop tables if they exist
+DROP TABLE IF EXISTS comment_reactions CASCADE;
+
+DROP TABLE IF EXISTS post_reactions CASCADE;
+
 DROP TABLE IF EXISTS notifications CASCADE;
 
 DROP TABLE IF EXISTS comments CASCADE;
@@ -79,6 +83,22 @@ CREATE TABLE notifications (
     FOREIGN KEY (comment_id) REFERENCES comments (comment_id) ON DELETE CASCADE
 );
 
+CREATE TABLE post_reactions (
+    reaction_id SERIAL PRIMARY KEY,
+    user_id     INTEGER NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    post_id     INTEGER NOT NULL REFERENCES posts(post_id) ON DELETE CASCADE,
+    reaction    VARCHAR(10) NOT NULL CHECK (reaction IN ('like', 'dislike')),
+    CONSTRAINT unique_post_reaction UNIQUE (user_id, post_id)
+);
+
+CREATE TABLE comment_reactions (
+    reaction_id SERIAL PRIMARY KEY,
+    user_id     INTEGER NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    comment_id  INTEGER NOT NULL REFERENCES comments(comment_id) ON DELETE CASCADE,
+    reaction    VARCHAR(10) NOT NULL CHECK (reaction IN ('like', 'dislike')),
+    CONSTRAINT unique_comment_reaction UNIQUE (user_id, comment_id)
+);
+
 -- Create indexes for better query performance
 CREATE INDEX idx_posts_user_id ON posts (user_id);
 
@@ -91,3 +111,7 @@ CREATE INDEX idx_comments_user_id ON comments (user_id);
 CREATE INDEX idx_notifications_user_id ON notifications (user_id);
 
 CREATE INDEX idx_notifications_is_read ON notifications (user_id, is_read);
+
+CREATE INDEX idx_post_reactions_post_id ON post_reactions (post_id);
+
+CREATE INDEX idx_comment_reactions_comment_id ON comment_reactions (comment_id);

--- a/internal/handler/handlers.go
+++ b/internal/handler/handlers.go
@@ -989,3 +989,169 @@ func (h *Handler) createNotification(comment model.Comment) {
 }
 
 // #endregion
+
+// #region Post/Comment reaction handlers
+
+// POST /api/posts/{postId}/react - Like or dislike a post
+func (h *Handler) ReactToPost(w http.ResponseWriter, r *http.Request) {
+	log.Info().Msg("POST /api/posts/{postId}/react - Reacting to a post")
+
+	username := middleware.GetUsername(r)
+	if username == "" {
+		log.Warn().Msg("No username in the context")
+		writeErrorResponse(w, http.StatusUnauthorized, "Not authenticated")
+		return
+	}
+
+	user, err := h.db.GetUserByUsername(username)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to get user")
+		writeErrorResponse(w, http.StatusInternalServerError, "Failed to get user")
+		return
+	}
+
+	vars := mux.Vars(r)
+	postId, err := strconv.Atoi(vars["postId"])
+	if err != nil {
+		log.Warn().Str("Post ID", vars["postId"]).Msg("Invalid post ID format")
+		writeErrorResponse(w, http.StatusBadRequest, "Invalid post ID")
+		return
+	}
+
+	var req struct {
+		Reaction string `json:"reaction"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		log.Warn().Err(err).Msg("Invalid request body")
+		writeErrorResponse(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+
+	if req.Reaction != "like" && req.Reaction != "dislike" {
+		log.Warn().Str("Reaction", req.Reaction).Msg("Invalid reaction value")
+		writeErrorResponse(w, http.StatusBadRequest, "Reaction must be 'like' or 'dislike'")
+		return
+	}
+
+	counts, err := h.db.GetPostReactionCounts(postId, user.ID)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to get post reaction counts")
+		writeErrorResponse(w, http.StatusInternalServerError, "Failed to get reaction counts")
+		return
+	}
+
+	reaction := model.Reaction {
+		UserId: user.ID,
+		TargetId: postId,
+		Reaction: req.Reaction,
+	}
+
+	// Same reaction clicked twice (toggle off)
+	if counts.UserReaction != nil && *counts.UserReaction == req.Reaction {
+		if err := h.db.DeletePostReaction(reaction); err != nil {
+			log.Error().Err(err).Msg("Failed to delete post reaction")
+			writeErrorResponse(w, http.StatusInternalServerError, "Failed to remove reaction")
+			return
+		}
+	} else {
+		// Insert or switch reaction
+		if err := h.db.UpsertPostReaction(reaction); err != nil {
+			log.Error().Err(err).Msg("Failed to upsert post reaction")
+			writeErrorResponse(w, http.StatusInternalServerError, "Failed to save reaction")
+			return
+		}
+	}
+
+	// Return updated counts
+	updatedCounts, err := h.db.GetPostReactionCounts(postId, user.ID)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to get updated post reaction counts")
+		writeErrorResponse(w, http.StatusInternalServerError, "Failed to get updated counts")
+		return
+	}
+
+	log.Info().Int("Post ID", postId).Str("Reaction", req.Reaction).Msg("Successfully reacted to post")
+	writeJSONResponse(w, http.StatusOK, updatedCounts)
+}
+
+// POST /api/comments/{commentId}/react - Like or dislike a comment
+func (h *Handler) ReactToComment(w http.ResponseWriter, r *http.Request) {
+	log.Info().Msg("POST /api/comments/{commentId}/react - Reacting to a comment")
+
+	username := middleware.GetUsername(r)
+	if username == "" {
+		log.Warn().Msg("No username in the context")
+		writeErrorResponse(w, http.StatusUnauthorized, "Not authenticated")
+		return
+	}
+
+	user, err := h.db.GetUserByUsername(username)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to get user")
+		writeErrorResponse(w, http.StatusInternalServerError, "Failed to get user")
+		return
+	}
+
+	vars := mux.Vars(r)
+	commentId, err := strconv.Atoi(vars["commentId"])
+	if err != nil {
+		log.Warn().Str("Comment ID", vars["commentId"]).Msg("Invalid comment ID format")
+		writeErrorResponse(w, http.StatusBadRequest, "Invalid comment ID")
+		return
+	}
+
+	var req struct {
+		Reaction string `json:"reaction"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		log.Warn().Err(err).Msg("Invalid request body")
+		writeErrorResponse(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+
+	if req.Reaction != "like" && req.Reaction != "dislike" {
+		log.Warn().Str("Reaction", req.Reaction).Msg("Invalid reaction value")
+		writeErrorResponse(w, http.StatusBadRequest, "Reaction must be 'like' or 'dislike'")
+		return
+	}
+
+	counts, err := h.db.GetCommentReactionCounts(commentId, user.ID)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to get comment reaction counts")
+		writeErrorResponse(w, http.StatusInternalServerError, "Failed to get reaction counts")
+		return
+	}
+
+	reaction := model.Reaction {
+		UserId: user.ID,
+		TargetId: commentId,
+		Reaction: req.Reaction,
+	}
+
+	// Same reaction clicked twice (toggle off)
+	if counts.UserReaction != nil && *counts.UserReaction == req.Reaction {
+		if err := h.db.DeleteCommentReaction(reaction); err != nil {
+			log.Error().Err(err).Msg("Failed to delete comment reaction")
+			writeErrorResponse(w, http.StatusInternalServerError, "Failed to remove reaction")
+			return
+		}
+	} else {
+		// Insert or switch reaction
+		if err := h.db.UpsertCommentReaction(reaction); err != nil {
+			log.Error().Err(err).Msg("Failed to upsert comment reaction")
+			writeErrorResponse(w, http.StatusInternalServerError, "Failed to save reaction")
+			return
+		}
+	}
+
+	// Return updated counts
+	updatedCounts, err := h.db.GetCommentReactionCounts(commentId, user.ID)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to get updated comment reaction counts")
+		writeErrorResponse(w, http.StatusInternalServerError, "Failed to get updated counts")
+		return
+	}
+
+	log.Info().Int("Comment ID", commentId).Str("Reaction", req.Reaction).Msg("Successfully reacted to comment")
+	writeJSONResponse(w, http.StatusOK, updatedCounts)
+}

--- a/internal/handler/handlers.go
+++ b/internal/handler/handlers.go
@@ -125,8 +125,34 @@ func (h *Handler) GetCommentsOnPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	username := middleware.GetUsername(r)
+	if username == "" {
+		log.Warn().Msg("Failed to get username in the context")
+		writeErrorResponse(w, http.StatusUnauthorized, "Unauthorized user")
+		return
+	}
+
+	user, err := h.db.GetUserByUsername(username)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to get user info")
+		writeErrorResponse(w, http.StatusInternalServerError, "Failed to get user")
+		return
+	}
+
+	var response []model.CommentResponse
+	for _, c := range comments {
+		counts, err := h.db.GetCommentReactionCounts(c.CommentId, user.ID)
+		if err != nil {
+			log.Error().Err(err).Int("Comment ID", c.CommentId).Msg("Failed to get comment reaction counts")
+			writeErrorResponse(w, http.StatusInternalServerError, "Failed to get reaction counts")
+			return
+		}
+
+		response = append(response, model.CommentResponse{Comment: c, Reactions: counts})
+	}
+
 	log.Info().Int("count", len(comments)).Msg("Successfully retrieved comments on post")
-	writeJSONResponse(w, http.StatusOK, comments)
+	writeJSONResponse(w, http.StatusOK, response)
 
 }
 
@@ -402,8 +428,35 @@ func (h *Handler) GetPostById(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	viewerId := 0
+
+	// Get authenticated user from context
+	username := middleware.GetUsername(r)
+	if username == "" {
+		log.Warn().Msg("No username in the context")
+		writeErrorResponse(w, http.StatusUnauthorized, "Not authenticated")
+		return
+	}
+
+	// Get the user from the db
+	user, err := h.db.GetUserByUsername(username)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to get user")
+		writeErrorResponse(w, http.StatusInternalServerError, "failed to get user")
+		return
+	}
+
+	viewerId = user.ID
+
+	counts, err := h.db.GetPostReactionCounts(id, viewerId)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to get post reaction counts")
+		writeErrorResponse(w, http.StatusInternalServerError, "Failed to get reaction counts")
+		return
+	}
+
 	log.Info().Int("Post ID", id).Msg("Successfully retrieved post by ID")
-	writeJSONResponse(w, http.StatusOK, post)
+	writeJSONResponse(w, http.StatusOK, model.PostResponse{Post: *post, Reactions: counts})
 }
 
 // GET /api/posts/user/{userId} - Handler to get all posts by UserID
@@ -1040,8 +1093,8 @@ func (h *Handler) ReactToPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	reaction := model.Reaction {
-		UserId: user.ID,
+	reaction := model.Reaction{
+		UserId:   user.ID,
 		TargetId: postId,
 		Reaction: req.Reaction,
 	}
@@ -1122,8 +1175,8 @@ func (h *Handler) ReactToComment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	reaction := model.Reaction {
-		UserId: user.ID,
+	reaction := model.Reaction{
+		UserId:   user.ID,
 		TargetId: commentId,
 		Reaction: req.Reaction,
 	}

--- a/internal/model/models.go
+++ b/internal/model/models.go
@@ -61,3 +61,13 @@ type ReactionCounts struct {
 	Dislikes     int     `json:"dislikes" db:"dislikes"`
 	UserReaction *string `json:"user_reaction" db:"user_reaction"`
 }
+
+type PostResponse struct {
+	Post
+	Reactions ReactionCounts `json:"reactions"`
+}
+
+type CommentResponse struct {
+	Comment
+	Reactions ReactionCounts `json:"reactions"`
+}

--- a/internal/model/models.go
+++ b/internal/model/models.go
@@ -49,3 +49,9 @@ type Notification struct {
 	CreatedAt time.Time `json:"created_at" db:"created_at"`
 	CommentId *int      `json:"comment_id" db:"comment_id"`
 }
+
+type ReactionCounts struct {
+	Likes int `json:"likes" db:"likes"`
+	Dislikes int `json:"dislikes" db:"dislikes"`
+	UserReaction *string `json:"user_reaction" db:"user_reaction"`
+}

--- a/internal/model/models.go
+++ b/internal/model/models.go
@@ -50,8 +50,14 @@ type Notification struct {
 	CommentId *int      `json:"comment_id" db:"comment_id"`
 }
 
+type Reaction struct {
+	UserId   int    `json:"user_id" db:"user_id"`
+	TargetId int    `json:"target_id"`
+	Reaction string `json:"reaction" db:"reaction"`
+}
+
 type ReactionCounts struct {
-	Likes int `json:"likes" db:"likes"`
-	Dislikes int `json:"dislikes" db:"dislikes"`
+	Likes        int     `json:"likes" db:"likes"`
+	Dislikes     int     `json:"dislikes" db:"dislikes"`
 	UserReaction *string `json:"user_reaction" db:"user_reaction"`
 }

--- a/internal/repository/database.go
+++ b/internal/repository/database.go
@@ -648,3 +648,134 @@ func (db *DB) CreateNotification(notif *model.Notification) error {
 }
 
 // #endregion
+
+// # region User Reactions
+
+// Post Reactions
+func (db *DB) UpsertPostReaction(reaction model.Reaction) error {
+	query := `
+		INSERT INTO post_reactions (user_id, post_id, reaction) 
+		VALUES ($1, $2, $3) 
+		ON CONFLICT (user_id, post_id) 
+		DO UPDATE SET reaction = EXCLUDED.reaction;
+	`
+
+	_, err := db.Exec(query, reaction.UserId, reaction.TargetId, reaction.Reaction)
+	if err != nil {
+		return fmt.Errorf("failed to upsert post reaction: %w", err)
+	}
+
+	return nil
+}
+
+// Remove post reaction
+func (db *DB) DeletePostReaction(reaction model.Reaction) error {
+	query := `
+		DELETE FROM post_reactions 
+		WHERE user_id = $1 AND post_id = $2;
+	`
+
+	result, err := db.Exec(query, reaction.UserId, reaction.TargetId)
+	if err != nil {
+		return fmt.Errorf("failed to delete post reaction: %w", err)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("reaction not found")
+	}
+
+	return nil
+}
+
+// Get the counts of the post likes and dislikes
+func (db *DB) GetPostReactionCounts(postId, viewerId int) (model.ReactionCounts, error) {
+	query := `
+	SELECT
+		COUNT(*) FILTER (WHERE reaction = 'like') AS likes,
+		COUNT(*) FILTER (WHERE reaction = 'dislike') AS dislikes,
+		MAX(reaction) FILTER (WHERE user_id = $2) AS user_reaction
+	FROM post_reactions 
+	WHERE post_id = $1;
+	`
+
+	var count model.ReactionCounts
+	err := db.QueryRow(query, postId, viewerId).Scan(
+		&count.Likes,
+		&count.Dislikes,
+		&count.UserReaction,
+	)
+	if err != nil {
+		return model.ReactionCounts{}, fmt.Errorf("failed to get post reaction counts: %w", err)
+	}
+
+	return count, nil
+}
+
+// Comment Reactions
+func (db *DB) UpsertCommentReaction(reaction model.Reaction) error {
+	query := `
+		INSERT INTO comment_reactions (user_id, comment_id, reaction) 
+		VALUES ($1, $2, $3) 
+		ON CONFLICT (user_id, comment_id) 
+		DO UPDATE SET reaction = EXCLUDED.reaction;
+	`
+
+	_, err := db.Exec(query, reaction.UserId, reaction.TargetId, reaction.Reaction)
+	if err != nil {
+		return fmt.Errorf("failed to upsert comment reaction: %w", err)
+	}
+
+	return nil
+}
+
+// Remove comment reaction
+func (db *DB) DeleteCommentReaction(reaction model.Reaction) error {
+	query := `
+		DELETE FROM comment_reactions 
+		WHERE user_id = $1 AND comment_id = $2;
+	`
+
+	result, err := db.Exec(query, reaction.UserId, reaction.TargetId)
+	if err != nil {
+		return fmt.Errorf("failed to delete comment reaction: %w", err)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get the rows affected: %w", err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("reaction not found")
+	}
+
+	return nil
+}
+
+// Get the counts of the comment likes and dislikes
+func (db *DB) GetCommentReactionCounts(commentId, viewerId int) (model.ReactionCounts, error) {
+	query := `
+	SELECT
+		COUNT(*) FILTER (WHERE reaction = 'like') AS likes,
+		COUNT(*) FILTER (WHERE reaction = 'dislike') AS dislikes,
+		MAX(reaction) FILTER (WHERE user_id = $2) AS user_reaction
+	FROM comment_reactions 
+	WHERE comment_id = $1;
+	`
+
+	var count model.ReactionCounts
+	err := db.QueryRow(query, commentId, viewerId).Scan(
+		&count.Likes,
+		&count.Dislikes,
+		&count.UserReaction,
+	)
+	if err != nil {
+		return model.ReactionCounts{}, fmt.Errorf("failed to get comment reaction counts: %w", err)
+	}
+
+	return count, nil
+}
+// #endregion


### PR DESCRIPTION
## Summary

Implements a full reaction system (likes/dislikes) for posts and comments, including database tables, repository methods, API handlers, and enriched response models.

## Changes

- Add `post_reactions` and `comment_reactions` database tables
- Add `ReactionCounts` and `Reaction` models
- Add `PostResponse` and `CommentResponse` structs that embed reaction counts
- Add repository methods: upsert, delete, and get reaction counts for posts and comments
- Add `ReactToPost` and `ReactToComment` handlers with toggle support
- Register reaction routes: `POST /api/posts/{postId}/react` and `POST /api/comments/{commentId}/react`
- Enrich `GetPostById` to return reaction counts for the authenticated viewer
- Enrich `GetCommentsOnPost` to return per-comment reaction counts
- Move GET endpoints for comments, posts, and profiles to the protected (JWT-required) subrouter

## Testing

- [x] React to a post with like/dislike
- [x] Toggle off a reaction by sending the same reaction twice
- [x] Switch reaction from like to dislike and vice versa
- [x] Verify reaction counts returned on GetPostById
- [x] Verify reaction counts returned on GetCommentsOnPost
- [x] Confirm unauthenticated requests to GET endpoints are rejected