### PR TITLE
fix(reactions): delete old notification before creating new one on reaction switch

### DIFF
--- a/internal/handler/reactions.go
+++ b/internal/handler/reactions.go
@@ -90,7 +90,14 @@ func (h *Handler) ReactToPost(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if post.UserId != user.ID {
-			go h.createReactionNotification(nil, post, user.Username, req.Reaction)
+			prevReaction := counts.UserReaction
+			go func() {
+				if prevReaction != nil {
+					// Switch reaction - delete old notification before making new one
+					h.db.DeleteReactionNotification(post.UserId, postId, nil)
+				}
+				h.createReactionNotification(nil, post, user.Username, req.Reaction)
+			}()
 		}
 	}
 
@@ -186,7 +193,14 @@ func (h *Handler) ReactToComment(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if comment.UserId != user.ID {
-			go h.createReactionNotification(comment, nil, user.Username, req.Reaction)
+			prevReaction := counts.UserReaction
+			go func() {
+				if prevReaction != nil {
+					// Switch reaction - delete old notif before making new one
+					h.db.DeleteReactionNotification(comment.UserId, comment.PostId, &commentId)
+				}
+				h.createReactionNotification(comment, nil, user.Username, req.Reaction)
+			}()
 		}
 	}
 


### PR DESCRIPTION
## Summary
Fixes duplicate reaction notifications when a user switches their reaction (e.g. like to dislike). Previously, only a new notification was created without removing the old one.

## Changes
- Delete existing reaction notification before creating a new one when switching reactions on posts
- Delete existing reaction notification before creating a new one when switching reactions on comments

## Testing
- [x] Manual testing: switch reaction on a post and verify only one notification exists
- [x] Manual testing: switch reaction on a comment and verify only one notification exists