### PR TITLE
feat(health): add GET /api/health endpoint

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -114,6 +114,7 @@ func setupRouter(h *handler.Handler, authMiddleware *middleware.AuthMiddleware) 
 	admin.Use(middleware.RequireRole("admin"))
 
 	// Login/Register endpoints
+	api.HandleFunc("/health", h.GetHealth).Methods("GET")
 	api.HandleFunc("/register", h.Register).Methods("POST")
 	api.HandleFunc("/login", h.Login).Methods("POST")
 

--- a/internal/handler/health.go
+++ b/internal/handler/health.go
@@ -1,0 +1,14 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/rs/zerolog/log"
+)
+
+// GET /api/health - Check the health of the service
+func (h *Handler) GetHealth(w http.ResponseWriter, r *http.Request) {
+
+	log.Info().Msg("GET /api/health - Getting Service Health")
+	writeJSONResponse(w, http.StatusOK, map[string]string{"status": "ok"})
+}


### PR DESCRIPTION
## Summary
Adds a public health check endpoint to verify the service is running.

## Changes
- Add `internal/handler/health.go` with `GetHealth` handler returning `{"status": "ok"}`
- Register `GET /api/health` on the public API subrouter (no JWT required)

## Testing
- [x] Manual: `curl /api/health` returns `200 {"status": "ok"}`
- [x] Verify endpoint is accessible without a JWT token